### PR TITLE
chore: update CODEOWNERS team refs to rewind-community

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @rewindio/devops
+* @rewind-community/devops


### PR DESCRIPTION
# **Jira:** [DEVOPS-4349](https://rewind.atlassian.net/browse/DEVOPS-4349)

## Description of Change

This repo was moved from `rewindio` to `rewind-community`. CODEOWNERS still referenced `@rewindio/devops`; cross-org team refs are silently dropped by GitHub, so codeowner review was effectively disabled. Updating to `@rewind-community/devops` restores it.

## Related PRs

- rewindio/terraform-rewindio-github#365

## Testing Performed

Team `rewind-community/devops` exists. Visual diff review.